### PR TITLE
Fix gallery header alignment with emoji-aware width calculation

### DIFF
--- a/gallery.sh
+++ b/gallery.sh
@@ -40,12 +40,18 @@ clear
 # Header
 echo ""
 echo -e "${COLOR_HEADER}${BOLD}"
+
+# Define the box width (inner content width)
+header_inner_width=59
+
+# Build the header lines with proper padding
+# Note: Using _pad_to_width ensures emoji and wide characters are handled correctly
 echo "  ╔═══════════════════════════════════════════════════════════╗"
-echo "  ║                                                           ║"
-echo "  ║   🐦  Oiseau - Modern Terminal UI Library for Bash       ║"
-echo "  ║                                                           ║"
-echo "  ║   A showcase of all available widgets and components     ║"
-echo "  ║                                                           ║"
+echo "  ║$(_pad_to_width "" $header_inner_width)║"
+echo "  ║$(_pad_to_width "   🐦  Oiseau - Modern Terminal UI Library for Bash" $header_inner_width)║"
+echo "  ║$(_pad_to_width "" $header_inner_width)║"
+echo "  ║$(_pad_to_width "   A showcase of all available widgets and components" $header_inner_width)║"
+echo "  ║$(_pad_to_width "" $header_inner_width)║"
 echo "  ╚═══════════════════════════════════════════════════════════╝"
 echo -e "${RESET}"
 


### PR DESCRIPTION
## Problem

The gallery header box had misaligned vertical borders due to incorrect spacing on lines with emojis. The emoji 🐦 takes 2 visual columns in terminals but was being counted as 1 character, causing the padding calculations to be off.

## Solution

Added two new helper functions to `oiseau.sh`:

1. **`_display_width()`** - Calculates the actual display width of a string, accounting for wide characters like emojis that take 2 columns. Uses perl's `Text::VisualWidth::PP` module if available, otherwise falls back to a heuristic (character count + emoji count).

2. **`_pad_to_width()`** - Pads a string to a specific display width by calculating the current display width and adding the appropriate number of spaces.

Updated `gallery.sh` header to use `_pad_to_width()` instead of hard-coded spacing, ensuring all lines are padded to exactly 59 display columns.

## Result

The vertical borders now align perfectly across all terminal modes (rich/color/plain), regardless of emoji width. The fix is robust and degrades gracefully when emoji support is unavailable.

## Before
\`\`\`
  ╔═══════════════════════════════════════════════════════════╗
  ║                                                           ║
  ║   🐦  Oiseau - Modern Terminal UI Library for Bash       ║  <- misaligned
  ║                                                           ║
  ║   A showcase of all available widgets and components     ║  <- misaligned
  ║                                                           ║
  ╚═══════════════════════════════════════════════════════════╝
\`\`\`

## After
\`\`\`
  ╔═══════════════════════════════════════════════════════════╗
  ║                                                           ║
  ║   🐦  Oiseau - Modern Terminal UI Library for Bash        ║  <- perfectly aligned
  ║                                                           ║
  ║   A showcase of all available widgets and components      ║  <- perfectly aligned
  ║                                                           ║
  ╚═══════════════════════════════════════════════════════════╝
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)