### PR TITLE
Fix missing right-hand vertical borders in section header and summary boxes

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -347,7 +347,9 @@ show_section_header() {
     echo -e "${COLOR_BORDER}${BOX_RTL}$(_repeat_char "${BOX_H}" "$inner_width")${BOX_RTR}${RESET}"
 
     # Title line
-    echo -e "${COLOR_BORDER}${BOX_V}${RESET}  ${COLOR_HEADER}${BOLD}${title}${RESET}"
+    local title_display_width=$(_display_width "$title")
+    local title_padding=$((inner_width - title_display_width - 2))
+    echo -e "${COLOR_BORDER}${BOX_V}${RESET}  ${COLOR_HEADER}${BOLD}${title}${RESET}$(_repeat_char " " "$title_padding")${COLOR_BORDER}${BOX_V}${RESET}"
 
     # Step counter and subtitle if provided
     if [ -n "$step_num" ] && [ -n "$total_steps" ]; then
@@ -355,7 +357,9 @@ show_section_header() {
         if [ -n "$subtitle" ]; then
             step_text="${step_text} › ${subtitle}"
         fi
-        echo -e "${COLOR_BORDER}${BOX_V}${RESET}  ${COLOR_MUTED}${step_text}${RESET}"
+        local step_display_width=$(_display_width "$step_text")
+        local step_padding=$((inner_width - step_display_width - 2))
+        echo -e "${COLOR_BORDER}${BOX_V}${RESET}  ${COLOR_MUTED}${step_text}${RESET}$(_repeat_char " " "$step_padding")${COLOR_BORDER}${BOX_V}${RESET}"
     fi
 
     echo -e "${COLOR_BORDER}${BOX_RBL}$(_repeat_char "${BOX_H}" "$inner_width")${BOX_RBR}${RESET}"
@@ -533,11 +537,18 @@ show_summary() {
     local inner_width=$((width - 2))
 
     echo -e "${COLOR_BORDER}${BOX_RTL}$(_repeat_char "${BOX_H}" "$inner_width")${BOX_RTR}${RESET}"
-    echo -e "${COLOR_BORDER}${BOX_V}${RESET}  ${COLOR_SUCCESS}${ICON_SUCCESS}  ${BOLD}${title}${RESET}"
+
+    local title_content="  ${ICON_SUCCESS}  ${title}"
+    local title_display_width=$(_display_width "$title_content")
+    local title_padding=$((inner_width - title_display_width))
+    echo -e "${COLOR_BORDER}${BOX_V}${RESET}  ${COLOR_SUCCESS}${ICON_SUCCESS}${RESET}  ${BOLD}${title}${RESET}$(_repeat_char " " "$title_padding")${COLOR_BORDER}${BOX_V}${RESET}"
+
     echo -e "${COLOR_BORDER}${BOX_VR}$(_repeat_char "${BOX_H}" "$inner_width")${BOX_VL}${RESET}"
 
     for item in "${items[@]}"; do
-        echo -e "${COLOR_BORDER}${BOX_V}${RESET}  $item"
+        local item_display_width=$(_display_width "$item")
+        local item_padding=$((inner_width - item_display_width - 2))
+        echo -e "${COLOR_BORDER}${BOX_V}${RESET}  $item$(_repeat_char " " "$item_padding")${COLOR_BORDER}${BOX_V}${RESET}"
     done
 
     echo -e "${COLOR_BORDER}${BOX_RBL}$(_repeat_char "${BOX_H}" "$inner_width")${BOX_RBR}${RESET}"


### PR DESCRIPTION
## Summary

Fixed incomplete box rendering where the right-hand vertical border character was missing from content lines in `show_section_header` and `show_summary` functions.

**Before:**
```
╭──────────────────────────────────────────────────────────╮
│  Deploy Application
│  Step 2 of 4 › Building Docker image
╰──────────────────────────────────────────────────────────╯
```

**After:**
```
╭──────────────────────────────────────────────────────────╮
│  Deploy Application                                      │
│  Step 2 of 4 › Building Docker image                     │
╰──────────────────────────────────────────────────────────╯
```

## Changes

- `show_section_header`: Added proper padding calculation and right border for both title and step text lines
- `show_summary`: Added proper padding calculation and right border for title and all item lines
- Both functions now use `_display_width` to correctly measure text width and `_repeat_char` to add appropriate padding before the closing border

The `show_box` function was already correctly using the `_pad_to_width` helper and did not require fixes.

## Test Plan

- [x] Tested `show_section_header` with various titles and subtitles
- [x] Tested `show_summary` with multiple items
- [x] Ran full gallery script to verify all widgets render correctly
- [x] Verified box borders align properly on both left and right sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)