### PR TITLE
Fix icon width calculations for proper box border alignment

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -191,11 +191,24 @@ _display_width() {
             my $width = 0;
             for my $char (split //, $_) {
                 my $code = ord($char);
+                # Special case: Common icon characters that modern terminals render as width 1
+                # These are technically in wide ranges but render narrow in most terminals
+                if (
+                    $code == 0x2713 ||  # ✓ Check mark
+                    $code == 0x2717 ||  # ✗ Ballot X
+                    $code == 0x26A0 ||  # ⚠ Warning sign
+                    $code == 0x2139 ||  # ℹ Information source
+                    $code == 0x25CB ||  # ○ White circle
+                    $code == 0x25CF ||  # ● Black circle
+                    $code == 0x2298     # ⊘ Circled division slash
+                ) {
+                    $width += 1;
+                }
                 # East Asian Width ranges (CJK, full-width, etc.)
                 # Based on Unicode East Asian Width property
                 # Note: Ambiguous-width characters (hiragana, katakana) are treated as wide
                 # for better compatibility with CJK-aware terminal emulators
-                if (
+                elsif (
                     # Hiragana
                     ($code >= 0x3040 && $code <= 0x309F) ||
                     # Katakana
@@ -244,7 +257,16 @@ _display_width() {
     local byte_count=$(LC_ALL=C printf %s "$clean" | wc -c | tr -d ' ')
     local estimated_wide=$(( (byte_count - char_count) / 2 ))
 
-    # Ensure we don't over-estimate
+    # Adjust for common icon characters that are narrow in modern terminals
+    # These have 3-byte UTF-8 encoding but render as width 1
+    local icon_count=0
+    for icon in "✓" "✗" "⚠" "ℹ" "○" "●" "⊘"; do
+        local count=$(echo -n "$clean" | grep -o "$icon" 2>/dev/null | wc -l | tr -d ' ')
+        icon_count=$((icon_count + count))
+    done
+    estimated_wide=$((estimated_wide - icon_count))
+
+    # Ensure we don't over-estimate or under-estimate
     if [ "$estimated_wide" -lt 0 ]; then
         estimated_wide=0
     fi


### PR DESCRIPTION
## Summary

Fixed box border misalignment caused by incorrect width calculations for common icon characters. Modern terminals render icons like ✗, ⚠, ℹ, ✓ as width 1, but they're in Unicode ranges traditionally treated as width 2.

## Problem

**Before:**
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  ✗  Connection Failed                                   ┃  ← Missing space
┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
```

**After:**
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  ✗  Connection Failed                                    ┃  ← Properly aligned
┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
```

## Changes

### Perl-based width calculation (primary method)
- Added special-case handling for common icons: ✓ ✗ ⚠ ℹ ○ ● ⊘
- These are now correctly measured as width 1 instead of width 2
- Icon checks happen before general wide-character range checks
- CJK and other wide characters still measured correctly as width 2

### Bash-only fallback (for systems without Perl)
- Added icon detection using grep to adjust width estimates
- Counts occurrences of common icon characters
- Subtracts from estimated wide character count
- Ensures graceful degradation on minimal systems

## Dependencies

- **Primary**: Perl (available on 99% of Unix systems)
- **Fallback**: Standard POSIX utilities (sed, wc, tr, grep)
- **Graceful degradation**: Works without Perl, slightly less accurate

## Test Plan

- [x] Tested all icon characters (✓ ✗ ⚠ ℹ ○ ● ⊘) render with correct width
- [x] Verified CJK characters (你好, こんにちは, 안녕) still width 2
- [x] Tested all box types (error, warning, info, success)
- [x] Verified borders align in UTF-8 rich mode
- [x] Tested fallback behavior without Perl

## Related

This addresses the second issue discovered after PR #6 was merged. PR #6 fixed missing right borders in `show_section_header` and `show_summary`, but the styled boxes (`show_box`) still had misalignment due to icon width calculations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)