### PR TITLE
Fix MVC navigation colors not rendering

### DIFF
--- a/examples/tui_mvc.sh
+++ b/examples/tui_mvc.sh
@@ -89,12 +89,12 @@ view::header() {
 view::navigation() {
     local current=${MODEL[view]}
 
-    echo -n "  "
-    [ "$current" = "home" ] && echo -n "${COLOR_SUCCESS}[Home]${RESET}" || echo -n "${COLOR_MUTED}Home${RESET}"
-    echo -n "  "
-    [ "$current" = "tasks" ] && echo -n "${COLOR_SUCCESS}[Tasks]${RESET}" || echo -n "${COLOR_MUTED}Tasks${RESET}"
-    echo -n "  "
-    [ "$current" = "about" ] && echo -n "${COLOR_SUCCESS}[About]${RESET}" || echo -n "${COLOR_MUTED}About${RESET}"
+    echo -en "  "
+    [ "$current" = "home" ] && echo -en "${COLOR_SUCCESS}[Home]${RESET}" || echo -en "${COLOR_MUTED}Home${RESET}"
+    echo -en "  "
+    [ "$current" = "tasks" ] && echo -en "${COLOR_SUCCESS}[Tasks]${RESET}" || echo -en "${COLOR_MUTED}Tasks${RESET}"
+    echo -en "  "
+    [ "$current" = "about" ] && echo -en "${COLOR_SUCCESS}[About]${RESET}" || echo -en "${COLOR_MUTED}About${RESET}"
     echo ""
     echo ""
 }


### PR DESCRIPTION
## Problem

The MVC TUI demo navigation menu was displaying ANSI escape codes literally as text (`\033[38;5;246m`) instead of rendering as colors, making it unreadable.

## Root Cause

The `view::navigation()` function used `echo -n` which does NOT interpret escape sequences. Without the `-e` flag, bash treats the ANSI codes as literal text.

## Fix

Changed all `echo -n` to `echo -en` in the navigation function to enable escape sequence interpretation.

**Before:**
```bash
echo -n "${COLOR_MUTED}Home${RESET}"  # Shows: \033[38;5;246mHome\033[0m
```

**After:**
```bash
echo -en "${COLOR_MUTED}Home${RESET}"  # Renders: Home (in muted color)
```

## Test Plan

- [x] Run `examples/tui_mvc.sh`
- [x] Verify navigation menu shows colored text
- [x] Verify no literal escape codes visible
- [x] Test all three views (Home, Tasks, About)

## Note

This fix was committed after PR #9 was merged, so it didn't make it into that PR. Creating separate PR to get this critical fix into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)