### PR TITLE
Fix progress bar TTY detection for redirected output

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -567,8 +567,9 @@ show_progress_bar() {
             should_animate=1
         fi
     else
-        # Auto-detect: animate if TTY and not plain mode
-        if [ "$OISEAU_IS_TTY" = "1" ] && [ "$OISEAU_MODE" != "plain" ]; then
+        # Auto-detect: animate if stdout is a TTY and not plain mode
+        # Check at call time (not source time) to handle redirected output
+        if [ -t 1 ] && [ "$OISEAU_MODE" != "plain" ]; then
             should_animate=1
         fi
     fi


### PR DESCRIPTION
## Summary

Fixes the P1 issue identified in PR#16 Codex review: progress bar animation now correctly detects TTY status at call time instead of source time.

## Problem

The previous implementation checked `OISEAU_IS_TTY` which is set once when the library is sourced. When output was later redirected (e.g., `show_progress_bar ... > log`) or piped, the animation code would still write escape sequences (`\r`, `ESC[K`) to the log file instead of falling back to clean line-by-line output.

## Solution

Changed the TTY detection from:
```bash
if [ "$OISEAU_IS_TTY" = "1" ] && [ "$OISEAU_MODE" != "plain" ]; then
```

To:
```bash
if [ -t 1 ] && [ "$OISEAU_MODE" != "plain" ]; then
```

The `[ -t 1 ]` test checks if stdout (file descriptor 1) is a TTY **at call time**, ensuring correct behavior when output is redirected.

## Testing

✓ Animation works correctly when output is to TTY
✓ Clean line-by-line output when redirected to file  
✓ Clean line-by-line output when piped through commands
✓ No escape sequences in redirected output
✓ Correct line count in redirected output

## Resolves

- PR#16 Codex review feedback (P1 priority)
- oiseau.sh:571 TTY detection issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)