### PR TITLE
Update README to include comprehensive widget reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Output:
 
 ## 📚 Widget Reference
 
+Oiseau includes **25+ widgets** organized into the following categories:
+
 ### Status Messages
 
 | Function | Description |
@@ -168,23 +170,24 @@ Output:
 |----------|-------------|
 | `show_header "title"` | Simple bold header |
 | `show_subheader "title"` | Muted subheader |
+| `show_header_box "title" [subtitle]` | Decorative boxed header with optional subtitle |
 | `show_section_header "title" [step] [total] [subtitle]` | Boxed header with optional step counter |
 
-### Boxes
+### Boxes & Containers
 
 | Function | Usage |
 |----------|-------|
 | `show_box <type> <title> <msg> [cmd...]` | Styled box with title, message, and optional commands |
+| `show_summary "title" "item1" "item2" ...` | Summary box with multiple items |
 
-Types: `error`, `warning`, `info`, `success`
+**Box Types:** `error`, `warning`, `info`, `success`
 
-### Progress & Lists
+### Progress Indicators
 
 | Function | Description |
 |----------|-------------|
 | `show_progress_bar <current> <total> [label]` | Animated progress bar with percentage |
-| `show_checklist <array_name>` | Checklist with status icons |
-| `show_summary "title" "item1" "item2" ...` | Summary box with items |
+| `show_checklist <array_name>` | Checklist with status icons (done/active/pending/skip) |
 
 **Progress Bar Features:**
 - **Auto-animation:** Updates in place when in TTY
@@ -202,6 +205,17 @@ for i in {1..100}; do
   show_progress_bar $i 100 "Downloading"
   sleep 0.05
 done
+```
+
+**Checklist Statuses:**
+```bash
+tasks=(
+    "done|Task completed|Additional info"
+    "active|Task in progress|Working..."
+    "pending|Task waiting|Not started"
+    "skip|Task skipped|Not needed"
+)
+show_checklist tasks
 ```
 
 ### Spinner (Loading Indicators)
@@ -323,12 +337,26 @@ done
 
 | Function | Description |
 |----------|-------------|
-| `print_kv "key" "value" [width]` | Key-value pair |
-| `print_command "cmd"` | Code-styled command |
+| `print_kv "key" "value" [width]` | Key-value pair with aligned columns |
+| `print_command "cmd"` | Code-styled command display |
+| `print_command_inline "text"` | Inline code-styled text |
 | `print_item "text"` | Bulleted list item |
-| `print_section "title"` | Section title |
-| `print_step <num> "text"` | Numbered step |
+| `print_section "title"` | Section title (colored header) |
+| `print_step <num> "text"` | Numbered step with text |
 | `print_next_steps "step1" "step2" ...` | Numbered next steps list |
+
+### Backward Compatibility Aliases
+
+The following `print_*` aliases are provided for backward compatibility:
+
+| Alias | Maps To |
+|-------|---------|
+| `print_info()` | `show_info()` |
+| `print_success()` | `show_success()` |
+| `print_error()` | `show_error()` |
+| `print_warning()` | `show_warning()` |
+| `print_header()` | `show_header()` |
+| `print_box()` | `show_summary()` |
 
 ---
 


### PR DESCRIPTION
## Summary

Updated the README Widget Reference section to provide comprehensive documentation of all available widgets:

- ✅ Added widget count intro (25+ widgets)
- ✅ Added missing `show_header_box` widget
- ✅ Reorganized "Progress & Lists" to "Progress Indicators" 
- ✅ Moved `show_summary` to "Boxes & Containers" section
- ✅ Added checklist status examples with all 4 statuses (done/active/pending/skip)
- ✅ Added `print_command_inline` to formatting helpers
- ✅ Added new "Backward Compatibility Aliases" section documenting all `print_*` aliases
- ✅ Improved descriptions for all formatting helpers

## Changes

### Widget Reference Updates
- Intro line stating "25+ widgets organized into categories"
- Added `show_header_box` widget (was missing from docs)
- Renamed "Boxes" → "Boxes & Containers" (now includes show_summary)
- Renamed "Progress & Lists" → "Progress Indicators" (clearer purpose)
- Added checklist status example showing all 4 statuses

### Formatting Helpers
- Added `print_command_inline` (was undocumented)
- Enhanced descriptions (e.g., "Key-value pair with aligned columns")

### New Section: Backward Compatibility Aliases
Documents all legacy `print_*` functions that map to `show_*` equivalents:
- `print_info()` → `show_info()`
- `print_success()` → `show_success()`
- `print_error()` → `show_error()`
- `print_warning()` → `show_warning()`
- `print_header()` → `show_header()`
- `print_box()` → `show_summary()`

## Test Plan

- [x] Verify README renders correctly on GitHub
- [x] Check all widget function names match implementation in oiseau.sh
- [x] Confirm examples are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)