### PR TITLE
Fix ANSI escape code rendering in styled boxes

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -725,33 +725,35 @@ show_box() {
     printf '%b%s%b%b\n' "${color}" "${BOX_DTL}$(_repeat_char "${BOX_DH}" "$inner_width")${BOX_DTR}" "${RESET}" ""
 
     # Title line (with proper right border)
-    # Security: Use printf %s for user content to prevent backslash injection
+    # Security: User content in title_content is already escaped via _escape_input at function start
+    # Use %b for the padded content because it contains ANSI escape codes (RESET and color)
     local title_content="  ${icon}  ${title}"
-    printf '%b%b%s%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "$title_content" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
+    printf '%b%b%b%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "$title_content" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
 
     # Separator
     printf '%b%s%b%b\n' "${color}" "${BOX_DVR}$(_repeat_char "${BOX_DH}" "$inner_width")${BOX_DVL}" "${RESET}" ""
 
     # Empty line
-    printf '%b%b%s%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
+    printf '%b%b%b%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
 
     # Message (word-wrapped if needed)
-    # Security: Use printf %s for user content to prevent backslash injection
+    # Security: User content in line is already escaped via _escape_input at function start
+    # Use %b for the padded content because it contains ANSI escape codes (RESET and color)
     echo "$message" | fold -s -w $((inner_width - 4)) | while IFS= read -r line; do
-        printf '%b%b%s%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "  $line" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
+        printf '%b%b%b%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "  $line" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
     done
 
     # Commands section if provided
     if [ "${#commands[@]}" -gt 0 ]; then
-        printf '%b%b%s%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
-        printf '%b%b%s%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "  To resolve:" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
+        printf '%b%b%b%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
+        printf '%b%b%b%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "  To resolve:" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
         for cmd in "${commands[@]}"; do
-            printf '%b%b%s%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "    ${cmd}" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
+            printf '%b%b%b%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "    ${cmd}" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
         done
     fi
 
     # Bottom empty line and border
-    printf '%b%b%s%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
+    printf '%b%b%b%b%b%b\n' "${color}" "${BOX_DV}" "${RESET}$(_pad_to_width "" "$inner_width")${color}" "${BOX_DV}" "${RESET}" ""
     printf '%b%s%b%b\n' "${color}" "${BOX_DBL}$(_repeat_char "${BOX_DH}" "$inner_width")${BOX_DBR}" "${RESET}" ""
 }
 


### PR DESCRIPTION
## Summary

- Fixed `show_box` function to properly render ANSI color codes instead of displaying them literally
- Changed `printf %s` to `printf %b` for parameters containing ANSI escape sequences
- Verified no other functions in codebase have similar issues

## Root Cause

The recent security fixes in PR #28 replaced `echo -e` with `printf` for safety, but used the wrong format specifier (`%s` instead of `%b`) for strings containing ANSI codes. This caused styled boxes to display raw escape sequences like `\033[0m` instead of rendering colors.

## Changes

Modified 7 lines in `show_box` function (oiseau.sh:731-756) to use `printf %b` for padded content containing ANSI codes.

## Security

This fix is safe because:
- User content is already escaped via `_escape_input()` at function entry
- ANSI codes come from controlled library variables, not user input  
- `%b` only interprets backslash escapes, doesn't execute commands

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)