### PR TITLE
Fix box alignment - remove header box indent

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -666,31 +666,31 @@ show_header_box() {
     printf '%b%b' "${COLOR_HEADER}" "${BOLD}"
 
     # Top border
-    printf '  %b%s%b\n' "${BOX_DTL}" "$(_repeat_char "${BOX_DH}" "$inner_width")" "${BOX_DTR}"
+    printf '%b%s%b\n' "${BOX_DTL}" "$(_repeat_char "${BOX_DH}" "$inner_width")" "${BOX_DTR}"
 
     # Empty line
-    printf '  %b%s%b\n' "${BOX_DV}" "$(_pad_to_width "" "$inner_width")" "${BOX_DV}"
+    printf '%b%s%b\n' "${BOX_DV}" "$(_pad_to_width "" "$inner_width")" "${BOX_DV}"
 
     # Title (word-wrapped if needed)
     # Security: Use printf %s for user content to prevent backslash injection
     echo "$title" | fold -s -w $((inner_width - 6)) | while IFS= read -r line; do
-        printf '  %b%s%b\n' "${BOX_DV}" "$(_pad_to_width "   $line" "$inner_width")" "${BOX_DV}"
+        printf '%b%s%b\n' "${BOX_DV}" "$(_pad_to_width "   $line" "$inner_width")" "${BOX_DV}"
     done
 
     # Empty line
-    printf '  %b%s%b\n' "${BOX_DV}" "$(_pad_to_width "" "$inner_width")" "${BOX_DV}"
+    printf '%b%s%b\n' "${BOX_DV}" "$(_pad_to_width "" "$inner_width")" "${BOX_DV}"
 
     # Subtitle (word-wrapped if needed)
     # Security: Use printf %s for user content to prevent backslash injection
     if [ -n "$subtitle" ]; then
         echo "$subtitle" | fold -s -w $((inner_width - 6)) | while IFS= read -r line; do
-            printf '  %b%s%b\n' "${BOX_DV}" "$(_pad_to_width "   $line" "$inner_width")" "${BOX_DV}"
+            printf '%b%s%b\n' "${BOX_DV}" "$(_pad_to_width "   $line" "$inner_width")" "${BOX_DV}"
         done
-        printf '  %b%s%b\n' "${BOX_DV}" "$(_pad_to_width "" "$inner_width")" "${BOX_DV}"
+        printf '%b%s%b\n' "${BOX_DV}" "$(_pad_to_width "" "$inner_width")" "${BOX_DV}"
     fi
 
     # Bottom border
-    printf '  %b%s%b\n' "${BOX_DBL}" "$(_repeat_char "${BOX_DH}" "$inner_width")" "${BOX_DBR}"
+    printf '%b%s%b\n' "${BOX_DBL}" "$(_repeat_char "${BOX_DH}" "$inner_width")" "${BOX_DBR}"
 
     echo -e "${RESET}"
 }


### PR DESCRIPTION
Removed the 2-space left indent from `show_header_box` to match `show_box` alignment.

## Problem
Header boxes had a 2-space left indent while content boxes (success, error, warning) had no indent, causing misalignment:

```
  ┏━━━━━━━━━━━━━━━━━━┓  (header - indented)
  ┃   Title          ┃
  ┗━━━━━━━━━━━━━━━━━━┛
┏━━━━━━━━━━━━━━━━━━┓    (content - no indent)
┃  ✓  Success!     ┃
┗━━━━━━━━━━━━━━━━━━┛
```

## Solution
Removed the `'  '` prefix from all printf statements in `show_header_box`.

## Result
All boxes now align at the left edge:

```
┏━━━━━━━━━━━━━━━━━━┓
┃   Title          ┃
┗━━━━━━━━━━━━━━━━━━┛
┏━━━━━━━━━━━━━━━━━━┓
┃  ✓  Success!     ┃
┗━━━━━━━━━━━━━━━━━━┛
```