### PR TITLE
Align progress output to 60-character box width

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -137,13 +137,19 @@ for i in "${!test_files[@]}"; do
     bar="${COLOR_SUCCESS}$(_repeat_char "$filled_char" "$filled")${COLOR_DIM}$(_repeat_char "$empty_char" "$empty")${RESET}"
     progress_display="Testing: ${bar} ${percent}% (${current}/${total})"
 
-    # Calculate available width for test name
-    # Format: "Testing: " (9) + bar (20) + " " (1) + percentage (4-5) + " (X/YY)" (6-8) + "  " (2) + icon (1) + "  " (2)
-    # Total fixed width: ~45-50 characters
-    # Leave room for test name to fit within terminal width
-    max_name_width=$((OISEAU_WIDTH - 50))
-    if [ "$max_name_width" -lt 15 ]; then
-        max_name_width=15  # Minimum reasonable width
+    # Calculate available width for test name to match box width (60 chars)
+    # Format: "Testing: " (9) + bar (20) + " " (1) + percentage (4) + " (X/YY)" (~7) + "  " (2) + icon (1) + "  " (2)
+    # Total fixed: ~46 characters, leaving ~14 for test name
+    max_line_width=60
+
+    # Calculate fixed width (without color codes which don't take visual space)
+    # "Testing: " = 9, bar = 20, " " = 1, percentage = 3-4, " (X/YY)" = 6-7, "  " = 2, icon = 1-4, "  " = 2
+    fixed_width=$((9 + 20 + 1 + 4 + 7 + 2 + 1 + 2))  # ~46 chars
+
+    # Calculate remaining space for test name
+    max_name_width=$((max_line_width - fixed_width))
+    if [ "$max_name_width" -lt 10 ]; then
+        max_name_width=10  # Minimum reasonable width
     fi
 
     # Truncate test name if needed


### PR DESCRIPTION
Aligns test runner progress lines to match the 60-character box width for visual consistency.

## Problem
Progress lines were calculated based on terminal width (`OISEAU_WIDTH - 50`), which could vary widely (30, 80, 130+ characters) and didn't align with the fixed 60-character boxes.

## Solution  
- Set `max_line_width` to 60 chars (matches header/summary boxes)
- Calculate fixed-width elements: ~46 chars
- Allocate remaining ~14 chars for test name
- Ensures consistent truncation and alignment

## Result
Progress lines now align perfectly with box borders:

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃   Oiseau Test Suite Runner                               ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

Testing: ████████████░░░░░░░░ 60% (6/10)  ✓  test_mode_con…

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃   Test Results Summary                                   ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

Clean visual alignment throughout the output.