### PR TITLE
Refactor: _repeat_char cache using arrays (Bash 3.x compatible)

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -90,10 +90,11 @@ if [ ! -d "$TEST_DIR" ]; then
 fi
 
 # Find all test files (Bash 3.x compatible)
+# Exclude lib directory to avoid picking up helper library
 test_files=()
 while IFS= read -r file; do
     test_files+=("$file")
-done < <(find "$TEST_DIR" -name "test_*.sh" -type f | sort)
+done < <(find "$TEST_DIR" -name "test_*.sh" -type f -not -path "*/lib/*" | sort)
 
 if [ ${#test_files[@]} -eq 0 ]; then
     show_box warning "No Tests Found" "No test files found in $TEST_DIR"


### PR DESCRIPTION
## Summary

- Refactor `_repeat_char` dynamic cache from 10 individual FIFO variables to 2 parallel arrays
- Fix test runner bug that incorrectly included `tests/lib/test_helpers.sh` as a test suite
- Increase dynamic cache from 5 to 10 slots for better hit rate
- Maintain Bash 3.x compatibility (originally attempted associative arrays but reverted for portability)

## Changes

### oiseau.sh
- Replace `_RC_DYN_KEY1-5` and `_RC_DYN_VAL1-5` with `OISEAU_RC_KEYS[]` and `OISEAU_RC_VALS[]` arrays
- Replace elif chain with for loop for cleaner cache lookup
- Increase cache size from 5 to 10 slots
- Keep static cache unchanged (18 hardcoded common patterns for maximum performance)

### run_tests.sh
- Add `-not -path "*/lib/*"` to find command to exclude helper library from test discovery
- Fixes bug where `tests/lib/test_helpers.sh` was incorrectly executed as a test

## Benefits

1. **Cleaner code**: 50% less code for FIFO management
2. **Easier maintenance**: Single array operations instead of manual variable rotation
3. **Better cache hit rate**: 10 slots vs 5 slots (2x capacity)
4. **Bug fix**: Test runner now correctly excludes helper library
5. **Bash 3.x compatible**: Uses arrays instead of associative arrays for macOS compatibility

## Testing

- ✅ All 10 test suites pass
- ✅ Tested in all modes (--rich, --color, --plain, --all)
- ✅ Verified on Bash 3.2.57 (macOS default)
- ✅ No performance regression (cache still works as expected)

## Related

Part of medium-priority optimizations from PR #39 assessment. This addresses the maintenance burden of manual FIFO cache management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)