### PR TITLE
Fix: Mode override detection + clarify --ansi/--ascii flags

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -24,7 +24,31 @@ if [ "${UI_DISABLE:-0}" = "1" ] || [ -n "${NO_COLOR+x}" ]; then
     export OISEAU_MODE="plain"
     export OISEAU_HAS_COLOR=0
     export OISEAU_HAS_UTF8=0
-else
+# Check if mode was explicitly set before sourcing (for testing/override)
+elif [ -n "${OISEAU_MODE+x}" ] && [ -n "$OISEAU_MODE" ]; then
+    # Mode override: set capabilities based on requested mode
+    case "$OISEAU_MODE" in
+        rich)
+            export OISEAU_HAS_COLOR=1
+            export OISEAU_HAS_UTF8=1
+            ;;
+        color)
+            export OISEAU_HAS_COLOR=1
+            export OISEAU_HAS_UTF8=0
+            ;;
+        plain)
+            export OISEAU_HAS_COLOR=0
+            export OISEAU_HAS_UTF8=0
+            ;;
+        *)
+            # Invalid mode, fall through to auto-detection
+            unset OISEAU_MODE
+            ;;
+    esac
+fi
+
+# Auto-detect mode if not explicitly set
+if [ -z "${OISEAU_MODE+x}" ] || [ -z "$OISEAU_MODE" ]; then
     # Detect if we're in a TTY
     if [[ -t 1 ]]; then
         export OISEAU_IS_TTY=1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -16,18 +16,18 @@
 set -eo pipefail
 
 # Parse command line arguments
-TEST_MODE="${1:-auto}"
+RAW_ARG="${1:-auto}"
 RUN_ALL_MODES=0
 
-case "$TEST_MODE" in
+case "$RAW_ARG" in
     --rich|--utf8)
-        export OISEAU_MODE="rich"
+        TEST_MODE="rich"
         ;;
-    --color|--ascii|--ansi)
-        export OISEAU_MODE="color"
+    --color|--ansi)
+        TEST_MODE="color"
         ;;
-    --plain)
-        export OISEAU_MODE="plain"
+    --plain|--ascii)
+        TEST_MODE="plain"
         ;;
     --all)
         RUN_ALL_MODES=1
@@ -36,18 +36,18 @@ case "$TEST_MODE" in
         echo "Usage: $0 [MODE]"
         echo ""
         echo "Modes:"
-        echo "  --rich, --utf8    Force UTF-8 mode (full Unicode)"
-        echo "  --color, --ascii  Force ASCII mode (no Unicode)"
-        echo "  --plain           Force plain mode (no colors)"
+        echo "  --rich, --utf8    Force UTF-8 mode (Unicode + Color)"
+        echo "  --color, --ansi   Force color mode (ASCII + Color)"
+        echo "  --plain, --ascii  Force plain mode (ASCII, no color)"
         echo "  --all             Run tests in all three modes"
         echo "  (default)         Auto-detect mode"
         exit 0
         ;;
     auto|"")
-        # Auto-detect (default behavior)
+        TEST_MODE="auto"
         ;;
     *)
-        echo "Error: Unknown mode '$TEST_MODE'"
+        echo "Error: Unknown mode '$RAW_ARG'"
         echo "Run '$0 --help' for usage information"
         exit 1
         ;;


### PR DESCRIPTION
## Summary

- Fix `OISEAU_MODE` override detection in oiseau.sh to respect pre-set values
- Fix run_tests.sh flag parsing (was passing `--rich` instead of `rich`)
- Clarify flag semantics: `--ansi` = colors, `--ascii` = plain

## Problem

When running `./run_tests.sh --rich`, the output showed ASCII borders (`+=====+`) instead of UTF-8 borders (`┏━━━┓`). Two bugs caused this:

1. **oiseau.sh**: Mode override not detected - auto-detection always ran and overwrote pre-set `OISEAU_MODE`
2. **run_tests.sh**: Argument parsing passed `--rich` to function instead of normalizing to `rich`

## Changes

### oiseau.sh (lines 22-96)

**Before**: Always ran auto-detection, ignored pre-set `OISEAU_MODE`

**After**: Check if `OISEAU_MODE` is set before sourcing:
```bash
elif [ -n "${OISEAU_MODE+x}" ] && [ -n "$OISEAU_MODE" ]; then
    # Mode override: set capabilities based on requested mode
    case "$OISEAU_MODE" in
        rich)  OISEAU_HAS_COLOR=1; OISEAU_HAS_UTF8=1 ;;
        color) OISEAU_HAS_COLOR=1; OISEAU_HAS_UTF8=0 ;;
        plain) OISEAU_HAS_COLOR=0; OISEAU_HAS_UTF8=0 ;;
    esac
fi

# Auto-detect only if mode not already set
if [ -z "${OISEAU_MODE+x}" ] || [ -z "$OISEAU_MODE" ]; then
    # ... auto-detection logic ...
fi
```

### run_tests.sh (lines 18-54)

**Before**: Passed `--rich` to `run_tests_in_mode()` which tried to export `OISEAU_MODE="--rich"`

**After**: Normalize flags to mode names:
```bash
case "$RAW_ARG" in
    --rich|--utf8)    TEST_MODE="rich" ;;
    --color|--ansi)   TEST_MODE="color" ;;
    --plain|--ascii)  TEST_MODE="plain" ;;
esac
```

**Flag mapping changes**:
- `--ascii` moved from "color" to "plain" (ASCII should have no color)
- `--ansi` stays with "color" (ANSI = color codes, not character set)

### Updated help text:
```
--rich, --utf8    Force UTF-8 mode (Unicode + Color)
--color, --ansi   Force color mode (ASCII + Color)
--plain, --ascii  Force plain mode (ASCII, no color)
```

## Mode Semantics Clarification

- **ANSI** = ANSI escape codes (for colors), NOT the character set
- **UTF-8** = Unicode box drawing characters (`┏━━━┓`)
- **ASCII** = Plain ASCII characters (`+=====+`)

**Three modes**:
1. **rich** (`--rich`, `--utf8`): UTF-8 borders + ANSI colors
2. **color** (`--color`, `--ansi`): ASCII borders + ANSI colors
3. **plain** (`--plain`, `--ascii`): ASCII borders + No colors

## Testing

**Before fix**:
```bash
$ ./run_tests.sh --rich
+==========================================================+  # Wrong! ASCII borders
```

**After fix**:
```bash
$ ./run_tests.sh --rich
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓  # Correct! UTF-8 borders

$ ./run_tests.sh --ansi
+==========================================================+  # ASCII + color

$ ./run_tests.sh --ascii
+==========================================================+  # ASCII, no color codes
```

- ✅ All 10 test suites pass in all modes
- ✅ `--all` runs all three modes successfully
- ✅ Mode override works for programmatic testing

## Benefits

1. **Correct visual output**: Flags now produce expected borders/icons
2. **Clearer semantics**: `--ansi` for colors, `--ascii` for plain
3. **Testing support**: Can override mode by setting `OISEAU_MODE` before sourcing
4. **Better UX**: Help text accurately describes mode capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)