### PR TITLE
Fix: Interactive menu scrolling up on arrow keys

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -1539,8 +1539,8 @@ ask_list() {
     render_list() {
         # Clear screen area (move cursor up and clear lines)
         if [ "$1" != "first" ]; then
-            # Move cursor up by number of items + header + footer
-            local lines_to_clear=$((${#items[@]} + 3))
+            # Move cursor up by number of items + prompt + help line
+            local lines_to_clear=$((${#items[@]} + 2))
             for ((i=0; i<lines_to_clear; i++)); do
                 echo -ne "\033[1A\033[2K" >&2  # Move up and clear line
             done


### PR DESCRIPTION
Fixes menu scrolling up when using arrow keys in ask_list().

## Problem
Each arrow key press causes the menu to move up one line, eventually scrolling past the header.

## Root Cause
render_list() was clearing `items + 3` lines but only re-rendering `items + 2` lines:
- 1 prompt line
- N item lines  
- 1 help line
= N + 2 total

## Solution
Changed lines_to_clear from `items + 3` to `items + 2`.

## Testing
✅ Menu stays in place when navigating with arrow keys
✅ No visual artifacts or glitches

🤖 Generated with [Claude Code](https://claude.com/claude-code)