### PR TITLE
Fix: ask_choice not displaying menu options

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -1131,6 +1131,13 @@ ask_choice() {
         return 1
     fi
 
+    # Sanitize all items for security
+    local sanitized_items=()
+    local idx
+    for idx in "${!items[@]}"; do
+        sanitized_items[idx]="$(_escape_input "${items[idx]}")"
+    done
+
     # Validate default is numeric if provided
     if [ -n "$default" ]; then
         if ! [[ "$default" =~ ^[0-9]+$ ]] || [ "$default" -lt 1 ] || [ "$default" -gt ${#items[@]} ]; then


### PR DESCRIPTION
Fixes empty menu options in ask_choice().

## Problem
Menu shows numbered items but no text:
```
  › 1. 
    2. 
    3. 
```

## Root Cause
`sanitized_items` array was referenced but never created. The function tried to display items from an uninitialized array.

## Solution
Add sanitization loop after loading items (lines 1134-1139).

## Testing
✅ Options now display correctly
✅ Navigation works
✅ Selection returns correct value

🤖 Generated with [Claude Code](https://claude.com/claude-code)