### PR TITLE
Fix: ask_choice menu scrolling up on arrow keys

### DIFF
--- a/oiseau.sh
+++ b/oiseau.sh
@@ -1200,7 +1200,7 @@ ask_choice() {
     render_choice_menu() {
         # Clear previous display (except on first render)
         if [ "$1" != "first" ]; then
-            local lines_to_clear=$((${#items[@]} + 3))
+            local lines_to_clear=$((${#items[@]} + 2))
             for ((i=0; i<lines_to_clear; i++)); do
                 echo -ne "\033[1A\033[2K" >&2
             done


### PR DESCRIPTION
Same scrolling bug as PR #47 but in ask_choice() instead of ask_list().

## Problem
Each arrow key press causes the choice menu to move up one line.

## Root Cause  
render_choice_menu() clearing `items + 3` lines but only rendering `items + 2`.

## Solution
Changed lines_to_clear from `items + 3` to `items + 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)