### PR TITLE
Fix box alignment in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ Output:
 ┃  ✗  Connection Failed                                    ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
 ┃                                                          ┃
-┃  Unable to reach database at localhost:5432             ┃
+┃  Unable to reach database at localhost:5432              ┃
 ┃                                                          ┃
 ┃  To resolve:                                             ┃
-┃    systemctl start postgresql                           ┃
-┃    pg_isready -h localhost                              ┃
+┃    systemctl start postgresql                            ┃
+┃    pg_isready -h localhost                               ┃
 ┃                                                          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 ```


### PR DESCRIPTION
## Summary
- Fixed inconsistent trailing spaces in error box example
- All content lines now have consistent padding for proper box alignment

## Changes
The error box example in the README had trailing space inconsistencies that caused the box borders to appear misaligned. This fix ensures all content lines have exactly 2 spaces of padding to match the 60-column box width.

**Before:**
```
┃  Unable to reach database at localhost:5432             ┃  (extra space)
┃    systemctl start postgresql                           ┃  (extra spaces)
```

**After:**
```
┃  Unable to reach database at localhost:5432              ┃  (consistent)
┃    systemctl start postgresql                            ┃  (consistent)
```

## Test Plan
- [x] Visual inspection of README rendering
- [x] Verified all box lines are exactly 60 characters wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)