### PR TITLE
Refactor README to 1980s technical manual style

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,20 @@ source ./oiseau.sh
 
 **REQUIREMENTS**
 
-- Bash 3.2+ (macOS default, all modern Linux)
-- Standard POSIX utilities: `tput`, `tr`, `printf`, `wc`, `grep`, `awk`, `sed`
-- Optional: `perl` (for unicode width calculations, degrades gracefully)
+Bash 3.2+ (macOS default, all modern Linux)
+
+POSIX utilities (universally available):
+- `tput` - terminal capability queries
+- `tr` - character translation for box drawing
+- `wc` - text width calculations
+- `grep` - pattern matching
+- `awk` - text processing
+- `sed` - text manipulation
+- `cat` - file concatenation
+- `sleep` - spinner animations
+
+Optional:
+- `perl` - unicode width calculations (degrades gracefully if missing)
 
 ---
 


### PR DESCRIPTION
## Summary

Transforms README from marketing-heavy docs to dense, no-nonsense technical reference manual - inspired by the classic Apple II Reference Manual, IBM PC Technical Reference, NeXT Developer Documentation, and Sun manuals.

## Changes

### Removed Marketing Content
- ❌ Emoji-heavy "Features" section
- ❌ "See It in Action" marketing copy
- ❌ "Real-World Example" tutorial content
- ❌ MADF section (tooling, not library itself)

### Condensed to Pure Reference
- ✅ Opening: 51 lines → 18 lines (62% reduction)
- ✅ All "Use cases" rewritten for hackers/nerds (technical, not corporate)
- ✅ Fixed "zero dependencies" claim to be technically accurate
- ✅ Kept only: Purpose, Installation, Requirements, Widget Catalog, Terminal Modes, Customization, Security, Testing, Troubleshooting

### What Stayed
- ✅ Complete widget catalog (32 widgets)
- ✅ All syntax/parameters/examples/output
- ✅ Terminal mode comparison
- ✅ Troubleshooting tables
- ✅ Everything needed for standalone reference

## Philosophy

Like 1980s technical manuals:
- **Dense** - High information density, zero fluff
- **Compact** - Facts only, no marketing speak
- **Standalone** - Everything you need, nothing you don't

Target audience: Hackers and nerds who want facts, not prose.

## Example Before/After

**Before (marketing):**
> Transform your bash scripts from plain text to beautiful, professional command-line interfaces.
> - **🎨 256-Color ANSI Palette** - Beautiful, modern color scheme
> - **⚡ Fast** - Caches terminal detection for minimal overhead

**After (technical):**
> 32 widgets for building terminal UIs in Bash 3.2+. Pure bash, no external libraries or packages. Graceful degradation: UTF-8+256color → ASCII+256color → ASCII monochrome.