### PR TITLE
Add multi-line progress bar support

### DIFF
--- a/test_multiline_progress.sh
+++ b/test_multiline_progress.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test multi-line progress bar support
+
+cd "$(dirname "$0")"
+source ./oiseau.sh
+
+echo "Testing multi-line progress bars..."
+echo ""
+echo ""  # Reserve 3 lines
+echo ""
+echo ""
+
+for i in {0..100}; do
+  # Update all 3 bars simultaneously on different lines
+  OISEAU_MODE=rich OISEAU_PROGRESS_ANIMATE=1 show_progress_bar "$i" 100 "Rich mode" 1
+  OISEAU_MODE=color OISEAU_PROGRESS_ANIMATE=1 show_progress_bar "$i" 100 "Color mode" 2
+  UI_DISABLE=1 OISEAU_PROGRESS_ANIMATE=1 show_progress_bar "$i" 100 "Plain mode" 3
+  sleep 0.05
+done
+
+# Move cursor past the progress bars
+echo ""
+echo ""
+echo ""
+echo "Done!"


### PR DESCRIPTION
## Summary
- Added optional 4th parameter `line_number` to `show_progress_bar()` function
- Enables multiple progress bars to update simultaneously on different lines
- Uses cursor positioning (`tput cup`) with ANSI fallback
- 100% backward compatible - existing code works unchanged
- Added security validation for line_number parameter

## Changes
- Modified `show_progress_bar()` in `oiseau.sh`:
  - Added optional 4th parameter for line positioning
  - Implemented cursor save/restore logic
  - Falls back to ANSI escape sequences if tput unavailable
  - Validates line_number is positive integer
- Created `test_multiline_progress.sh` demonstrating 3 simultaneous progress bars

## Use Cases
- Download progress with extraction and installation progress
- Multiple file operations running concurrently
- Any scenario requiring visual feedback for parallel tasks

## Test Plan
- [x] Run `test_multiline_progress.sh` - all 3 bars update correctly
- [x] Test single-line mode still works (backward compatibility)
- [x] Verify security validation (rejects invalid line numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)